### PR TITLE
Added missing grails-test-mixins test dependency to build.gradle

### DIFF
--- a/initial/build.gradle
+++ b/initial/build.gradle
@@ -53,6 +53,7 @@ dependencies {
     runtime "org.apache.tomcat:tomcat-jdbc"
     runtime "com.bertramlabs.plugins:asset-pipeline-grails:2.14.2"
     testCompile "org.grails:grails-gorm-testing-support"
+    testCompile "org.grails:grails-test-mixins:3.3.0"
     testCompile "org.grails.plugins:geb"
     testCompile "org.grails:grails-web-testing-support"
     testRuntime "org.seleniumhq.selenium:selenium-htmlunit-driver:2.47.1"


### PR DESCRIPTION
Added a test dependency, required by the auto-generated tests for the controllers, when running the scaffolding plugin